### PR TITLE
Updated tools.md

### DIFF
--- a/tools.md
+++ b/tools.md
@@ -41,6 +41,8 @@ Name | Description
 [Kernelpop](https://github.com/spencerdodd/kernelpop) | kernel privilege escalation enumeration and exploitation framework 
 [Lynis](https://github.com/CISOfy/lynis) | Security auditing tool for Linux, macOS, and UNIX-based systems.
 [linux-explorer](https://github.com/intezer/linux-explorer) | Easy-to-use live forensics toolbox for Linux endpoints
+[Katoolin](https://github.com/LionSec/katoolin) | Automatically install all Kali linux tools in distros like Ubuntu 
+
 
 ### Exploit Databases
 Name | Description


### PR DESCRIPTION
Added link to Katoolin - Katoolin allows for the addition and removal of Kali linux tools and repositories inside distros like Ubuntu.